### PR TITLE
Added a folder for PGrouting 2.1.0. Working version of PGrouting 2.1.0.

### DIFF
--- a/9.4-2.1-2.1/Dockerfile
+++ b/9.4-2.1-2.1/Dockerfile
@@ -1,0 +1,14 @@
+FROM mdillon/postgis:9.4
+MAINTAINER Hans Kristian Flaatten <hans.kristian.flaatten@turistforeningen.no>
+
+ENV PGROUTING_MAJOR 2.1
+ENV PGROUTING_VERSION 2.1.0-ppa1~vivid1
+COPY ./pgrouting.list /etc/apt/sources.list.d/pgrouting.list
+
+RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 26568B05B65ADE33 && \
+    apt-get update && \
+    apt-get install  -y --no-install-recommends \
+      postgresql-$PG_MAJOR-pgrouting=$PGROUTING_VERSION
+
+RUN mkdir -p /docker-entrypoint-initdb.d
+COPY ./initdb-pgrouting.sh /docker-entrypoint-initdb.d/routing.sh

--- a/9.4-2.1-2.1/initdb-pgrouting.sh
+++ b/9.4-2.1-2.1/initdb-pgrouting.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+set -e
+
+# Perform all actions as user 'postgres'
+export PGUSER=postgres
+
+# Add pgRouting Functions to the database
+psql --dbname="$POSTGRES_DB" <<EOSQL
+CREATE EXTENSION postgis;
+CREATE EXTENSION pgrouting;
+EOSQL

--- a/9.4-2.1-2.1/pgrouting.list
+++ b/9.4-2.1-2.1/pgrouting.list
@@ -1,0 +1,2 @@
+deb http://ppa.launchpad.net/georepublic/pgrouting-unstable/ubuntu vivid main 
+deb-src http://ppa.launchpad.net/georepublic/pgrouting-unstable/ubuntu vivid main 


### PR DESCRIPTION
This commit adds the sources for the PGrouting package. It signs the repository and then it install the correct version. Note that this only works with PG 9.4. If you require 9.3, then you need to use trusty instead of vivid in the version name of pgrouting.
